### PR TITLE
feat: Add endpoints for retrieving concern admins

### DIFF
--- a/.aws/task-definition.json
+++ b/.aws/task-definition.json
@@ -54,11 +54,20 @@
         {
           "name": "SENTRY_DSN",
           "valueFrom": "arn:aws:ssm:eu-west-2:430723991443:parameter/tis-revalidation-concern-sentry-dsn"
+        },
+        {
+          "name": "ADMIN_GROUP",
+          "valueFrom": "tis-revalidation-concern-admin-group"
+        },
+        {
+          "name": "ADMIN_USER_POOL",
+          "valueFrom": "tis-revalidation-cognito-pool-id-preprod"
         }
       ]
     }
   ],
   "executionRoleArn": "ecsTaskExecutionRole",
+  "taskRoleArn": "AwsTaskRoleForCognitoReadOnly",
   "family": "tis-revalidation-concerns",
   "requiresCompatibilities": [
     "FARGATE"

--- a/build.gradle
+++ b/build.gradle
@@ -9,9 +9,8 @@ plugins {
   id "org.sonarqube" version "2.8"
 }
 
-// TODO: Update group to end with "admin" or "trainee".
-group = "uk.nhs.hee.tis"
-version = "0.0.1"
+group = "uk.nhs.hee.tis.revalidation"
+version = "0.1.0"
 sourceCompatibility = "11"
 
 configurations {
@@ -29,6 +28,7 @@ dependencies {
   implementation "org.springframework.boot:spring-boot-starter-actuator"
   implementation "org.springframework.boot:spring-boot-starter-web"
   implementation "org.springframework.boot:spring-boot-starter-data-mongodb"
+
   testImplementation("org.springframework.boot:spring-boot-starter-test") {
     exclude group: "org.junit.vintage", module: "junit-vintage-engine"
   }
@@ -44,9 +44,11 @@ dependencies {
 
   // Sentry reporting
   compile "io.sentry:sentry-spring:1.7.30"
+
   implementation "com.github.javafaker:javafaker:1.0.2"
   implementation "io.springfox:springfox-swagger2:2.9.1"
   implementation "io.springfox:springfox-swagger-ui:2.9.1"
+  implementation "com.amazonaws:aws-java-sdk-cognitoidp:1.11.835"
 }
 
 checkstyle {

--- a/src/main/java/uk/nhs/hee/tis/revalidation/concerns/config/CognitoConfiguration.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/concerns/config/CognitoConfiguration.java
@@ -1,0 +1,36 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2020 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.revalidation.concerns.config;
+
+import com.amazonaws.services.cognitoidp.AWSCognitoIdentityProvider;
+import com.amazonaws.services.cognitoidp.AWSCognitoIdentityProviderClientBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class CognitoConfiguration {
+
+  @Bean
+  public AWSCognitoIdentityProvider getAwsIdentityProvider() {
+    return AWSCognitoIdentityProviderClientBuilder.defaultClient();
+  }
+}

--- a/src/main/java/uk/nhs/hee/tis/revalidation/concerns/controller/ConcernAdminController.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/concerns/controller/ConcernAdminController.java
@@ -1,0 +1,51 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2020 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.revalidation.concerns.controller;
+
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import uk.nhs.hee.tis.revalidation.concerns.dto.ConcernAdminDto;
+import uk.nhs.hee.tis.revalidation.concerns.service.ConcernAdminService;
+
+@RestController
+@RequestMapping("/api/concerns/admins")
+public class ConcernAdminController {
+
+  private ConcernAdminService service;
+
+  ConcernAdminController(ConcernAdminService service) {
+    this.service = service;
+  }
+
+  @ApiOperation(value = "Get a list of concern admins")
+  @ApiResponse(code = 200, message = "Look up successful", response = ConcernAdminDto.class, responseContainer = "List")
+  @GetMapping
+  public ResponseEntity<List<ConcernAdminDto>> getAssignableAdmins() {
+    List<ConcernAdminDto> admins = service.getAssignableAdmins();
+    return ResponseEntity.ok(admins);
+  }
+}

--- a/src/main/java/uk/nhs/hee/tis/revalidation/concerns/controller/ConcernAdminController.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/concerns/controller/ConcernAdminController.java
@@ -42,7 +42,8 @@ public class ConcernAdminController {
   }
 
   @ApiOperation(value = "Get a list of concern admins")
-  @ApiResponse(code = 200, message = "Look up successful", response = ConcernAdminDto.class, responseContainer = "List")
+  @ApiResponse(code = 200, message = "Look up successful",
+      response = ConcernAdminDto.class, responseContainer = "List")
   @GetMapping
   public ResponseEntity<List<ConcernAdminDto>> getAssignableAdmins() {
     List<ConcernAdminDto> admins = service.getAssignableAdmins();

--- a/src/main/java/uk/nhs/hee/tis/revalidation/concerns/dto/ConcernAdminDto.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/concerns/dto/ConcernAdminDto.java
@@ -1,0 +1,31 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2020 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.revalidation.concerns.dto;
+
+import lombok.Data;
+
+@Data
+public class ConcernAdminDto {
+
+  private String username;
+  private String fullName;
+}

--- a/src/main/java/uk/nhs/hee/tis/revalidation/concerns/mappers/ConcernAdminMapper.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/concerns/mappers/ConcernAdminMapper.java
@@ -1,0 +1,35 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2020 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.revalidation.concerns.mappers;
+
+import com.amazonaws.services.cognitoidp.model.UserType;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import uk.nhs.hee.tis.revalidation.concerns.dto.ConcernAdminDto;
+
+@Mapper(componentModel = "spring")
+public interface ConcernAdminMapper {
+
+  // TODO: Change to source from attributes when cognito has that information.
+  @Mapping(target = "fullName", source = "username")
+  ConcernAdminDto toDto(UserType userType);
+}

--- a/src/main/java/uk/nhs/hee/tis/revalidation/concerns/service/ConcernAdminService.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/concerns/service/ConcernAdminService.java
@@ -48,6 +48,11 @@ public class ConcernAdminService {
     this.mapper = mapper;
   }
 
+  /**
+   * Get a list of the admins that can be assigned to a concern.
+   *
+   * @return A list of admins.
+   */
   public List<ConcernAdminDto> getAssignableAdmins() {
     ListUsersInGroupRequest request = new ListUsersInGroupRequest();
     request.setGroupName(adminGroup);

--- a/src/main/java/uk/nhs/hee/tis/revalidation/concerns/service/ConcernAdminService.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/concerns/service/ConcernAdminService.java
@@ -1,0 +1,63 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2020 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.revalidation.concerns.service;
+
+import com.amazonaws.services.cognitoidp.AWSCognitoIdentityProvider;
+import com.amazonaws.services.cognitoidp.model.ListUsersInGroupRequest;
+import com.amazonaws.services.cognitoidp.model.ListUsersInGroupResult;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import uk.nhs.hee.tis.revalidation.concerns.dto.ConcernAdminDto;
+import uk.nhs.hee.tis.revalidation.concerns.mappers.ConcernAdminMapper;
+
+@Service
+public class ConcernAdminService {
+
+  @Value("${app.cognito.admin-group}")
+  private String adminGroup;
+
+  @Value("${app.cognito.admin-user-pool}")
+  private String adminUserPool;
+
+  private AWSCognitoIdentityProvider identityProvider;
+  private ConcernAdminMapper mapper;
+
+  ConcernAdminService(AWSCognitoIdentityProvider identityProvider, ConcernAdminMapper mapper) {
+    this.identityProvider = identityProvider;
+    this.mapper = mapper;
+  }
+
+  public List<ConcernAdminDto> getAssignableAdmins() {
+    ListUsersInGroupRequest request = new ListUsersInGroupRequest();
+    request.setGroupName(adminGroup);
+    request.setUserPoolId(adminUserPool);
+
+    // TODO: A limited number of users can be returned before pagination occurs, handle pagination.
+    ListUsersInGroupResult listUsersResult = identityProvider.listUsersInGroup(request);
+
+    return listUsersResult.getUsers().stream()
+        .map(mapper::toDto)
+        .collect(Collectors.toList());
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,13 +8,15 @@ spring:
     mongodb:
       uri: mongodb://${MONGODB_USERNAME:root}:${MONGODB_PASSWORD:password}@${MONGODB_HOST:localhost}:${MONGODB_PORT:27017}/${MONGODB_DATABASE:revalidation}?authSource=admin&authMechanism=SCRAM-SHA-1
 
-
 server:
   servlet:
     context-path: /concerns
   port: ${SERVICE_PORT:8087}
 
 app:
+  cognito:
+    admin-group: ${ADMIN_GROUP}
+    admin-user-pool: ${ADMIN_USER_POOL}
   concern:
     revalidation:
       url: ${REVALIDATION_URL:http://localhost:8080/revalidation/api}

--- a/src/test/java/uk/nhs/hee/tis/revalidation/concerns/controller/ConcernAdminControllerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/concerns/controller/ConcernAdminControllerTest.java
@@ -1,0 +1,84 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2020 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.revalidation.concerns.controller;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import uk.nhs.hee.tis.revalidation.concerns.dto.ConcernAdminDto;
+import uk.nhs.hee.tis.revalidation.concerns.service.ConcernAdminService;
+
+@ExtendWith(MockitoExtension.class)
+@WebMvcTest(ConcernAdminController.class)
+class ConcernAdminControllerTest {
+
+  private final MockMvc mockMvc;
+
+  @MockBean
+  private ConcernAdminService service;
+
+  @Autowired
+  ConcernAdminControllerTest(MockMvc mockMvc) {
+    this.mockMvc = mockMvc;
+  }
+
+  @Test
+  void shouldReturnEmptyListWhenNoAssignableAdminsFound() throws Exception {
+    when(service.getAssignableAdmins()).thenReturn(Collections.emptyList());
+
+    mockMvc.perform(get("/api/concerns/admins"))
+        .andExpect(status().isOk())
+        .andExpect(content().json("[]"));
+  }
+
+  @Test
+  void shouldReturnAdminsWhenAssignableAdminsFound() throws Exception {
+    ConcernAdminDto admin1 = new ConcernAdminDto();
+    admin1.setUsername("admin1");
+    admin1.setFullName("Admin One");
+
+    ConcernAdminDto admin2 = new ConcernAdminDto();
+    admin2.setUsername("admin2");
+    admin2.setFullName("Admin Two");
+
+    when(service.getAssignableAdmins()).thenReturn(Arrays.asList(admin1, admin2));
+
+    mockMvc.perform(get("/api/concerns/admins"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0].username").value("admin1"))
+        .andExpect(jsonPath("$[0].fullName").value("Admin One"))
+        .andExpect(jsonPath("$[1].username").value("admin2"))
+        .andExpect(jsonPath("$[1].fullName").value("Admin Two"));
+  }
+}

--- a/src/test/java/uk/nhs/hee/tis/revalidation/concerns/service/ConcernAdminServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/concerns/service/ConcernAdminServiceTest.java
@@ -1,0 +1,80 @@
+package uk.nhs.hee.tis.revalidation.concerns.service;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.amazonaws.services.cognitoidp.AWSCognitoIdentityProvider;
+import com.amazonaws.services.cognitoidp.model.ListUsersInGroupResult;
+import com.amazonaws.services.cognitoidp.model.UserType;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mapstruct.factory.Mappers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.nhs.hee.tis.revalidation.concerns.dto.ConcernAdminDto;
+import uk.nhs.hee.tis.revalidation.concerns.mappers.ConcernAdminMapper;
+
+@ExtendWith(MockitoExtension.class)
+class ConcernAdminServiceTest {
+
+  private ConcernAdminService service;
+
+  @Mock
+  private AWSCognitoIdentityProvider identityProvider;
+
+  @BeforeEach
+  void setUp() {
+    ConcernAdminMapper mapper = Mappers.getMapper(ConcernAdminMapper.class);
+    service = new ConcernAdminService(identityProvider, mapper);
+  }
+
+  @Test
+  void shouldReturnEmptyListWhenNoAssignableAdminsFound() {
+    // Given.
+    ListUsersInGroupResult listUsersInGroupResult = new ListUsersInGroupResult();
+    listUsersInGroupResult.setUsers(Collections.emptyList());
+
+    when(identityProvider.listUsersInGroup(any())).thenReturn(listUsersInGroupResult);
+
+    // When.
+    List<ConcernAdminDto> assignableAdmins = service.getAssignableAdmins();
+
+    // Then.
+    assertThat("Unexpected number of admins.", assignableAdmins.size(), is(0));
+  }
+
+  @Test
+  void shouldReturnAdminsWhenAssignableAdminsFound() {
+    // Given.
+    UserType user1 = new UserType();
+    user1.setUsername("user1");
+
+    UserType user2 = new UserType();
+    user2.setUsername("user2");
+
+    ListUsersInGroupResult listUsersInGroupResult = new ListUsersInGroupResult();
+    listUsersInGroupResult.setUsers(Arrays.asList(user1, user2));
+
+    when(identityProvider.listUsersInGroup(any())).thenReturn(listUsersInGroupResult);
+
+    // When.
+    List<ConcernAdminDto> admins = service.getAssignableAdmins();
+
+    // Then.
+    assertThat("Unexpected number of admins.", admins.size(), is(2));
+
+    ConcernAdminDto admin = admins.get(0);
+    assertThat("Unexpected username.", admin.getUsername(), is("user1"));
+    assertThat("Unexpected full name.", admin.getFullName(), is("user1"));
+
+    admin = admins.get(1);
+    assertThat("Unexpected username.", admin.getUsername(), is("user2"));
+    assertThat("Unexpected full name.", admin.getFullName(), is("user2"));
+  }
+}


### PR DESCRIPTION
Assignable admins should be retrieved from the Cognito user pool and
returned as a list of possible admins.

TISNEW-4972