### PR TITLE
refactor: Remove duplicate identity provider bean.

### DIFF
--- a/src/main/java/uk/nhs/hee/tis/revalidation/concerns/ConcernsApplication.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/concerns/ConcernsApplication.java
@@ -21,8 +21,6 @@
 
 package uk.nhs.hee.tis.revalidation.concerns;
 
-import com.amazonaws.services.cognitoidp.AWSCognitoIdentityProvider;
-import com.amazonaws.services.cognitoidp.AWSCognitoIdentityProviderClientBuilder;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
@@ -38,10 +36,5 @@ public class ConcernsApplication {
   @Bean
   public RestTemplate restTemplate() {
     return new RestTemplate();
-  }
-
-  @Bean
-  public AWSCognitoIdentityProvider getAwsIdentityProvider() {
-    return AWSCognitoIdentityProviderClientBuilder.defaultClient();
   }
 }


### PR DESCRIPTION
The bean was moved to its own configuration class, but was accidentally re-added as part of another commit.