### PR TITLE
chore: Add auto-caching using setup-java action

### DIFF
--- a/.github/workflows/ci-cd-workflow.yml
+++ b/.github/workflows/ci-cd-workflow.yml
@@ -14,9 +14,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Set up JDK 11
-        uses: actions/setup-java@v2.2.0
+      - name: Set up JDK
+        uses: actions/setup-java@v2.3.0
         with:
+          cache: gradle
           distribution: adopt
           java-version: 11
 
@@ -37,9 +38,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Set up JDK 11
-        uses: actions/setup-java@v2.2.0
+      - name: Set up JDK
+        uses: actions/setup-java@v2.3.0
         with:
+          cache: gradle
           distribution: adopt
           java-version: 11
 
@@ -60,9 +62,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Set up JDK 11
-        uses: actions/setup-java@v2.2.0
+      - name: Set up JDK
+        uses: actions/setup-java@v2.3.0
         with:
+          cache: gradle
           distribution: adopt
           java-version: 11
 
@@ -90,9 +93,10 @@ jobs:
           name: reports
           path: build/reports
 
-      - name: Set up JDK 11
-        uses: actions/setup-java@v2.2.0
+      - name: Set up JDK
+        uses: actions/setup-java@v2.3.0
         with:
+          cache: gradle
           distribution: adopt
           java-version: 11
 


### PR DESCRIPTION
The `setup-java` action now supports automatic caching of maven and
gradle dependencies, update the workflow to use that caching.

TIS21-2078