### PR TITLE
chore: update dependabot reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,12 +5,12 @@ updates:
     schedule:
       interval: weekly
     reviewers:
-      - Health-Education-England/full-stack
+      - Health-Education-England/internal-admin-backend
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
     reviewers:
-      - Health-Education-England/full-stack
-      - Health-Education-England/operations
+      - Health-Education-England/internal-admin-backend
+      - Health-Education-England/internal-admin-devops


### PR DESCRIPTION
Update dependabot reviewers to use the new product teams.

TIS21-SHED